### PR TITLE
img processing in-memory

### DIFF
--- a/src/ocr_tools.py
+++ b/src/ocr_tools.py
@@ -45,24 +45,16 @@ def get_pages_from_pdf(year = 2019, first_page =1, last_page = 5, plot = False):
         img = np.array(page) # convert PIL Image to numpy array
 
         # deskew image
-#        img = io.imread(f'out.png')
         angle = determine_skew(img)
-#        img_rotated = rotate(img, angle, resize=True) * 255
-#        io.imsave(f'out.png', img_rotated.astype(np.uint8))
         img = rotate(img, angle, resize=True) * 255
 
         # clip scanning boundaries
-#        img_clipped = img[50:-50,50:-50]
-#        cv.imwrite(f'out.png',img_clipped)
         img = img[50:-50,50:-50]
         
         # denoise image
-#        img = io.imread('out.png')
-#        img_denoised = cv.fastNlMeansDenoising(img, h = 50)
         img = cv.fastNlMeansDenoising(img, h = 50)
 
         # binary threshold
-#        _ ,img  = cv.threshold(img_denoised,150,255,cv.THRESH_BINARY)
         _ ,img  = cv.threshold(img,150,255,cv.THRESH_BINARY)
 
         # complete ocr
@@ -118,7 +110,6 @@ def get_pages_from_pdf(year = 2019, first_page =1, last_page = 5, plot = False):
                 plt.savefig(f'{settings.PROJECT_FOLDER}/data/{year}_image_bbox_logs/page_{first_page + i}.png')
                 plt.close(fig)
             
-#        os.remove(f"out.png")
         
     return df
 

--- a/src/ocr_tools.py
+++ b/src/ocr_tools.py
@@ -47,6 +47,7 @@ def get_pages_from_pdf(year = 2019, first_page =1, last_page = 5, plot = False):
         # deskew image
         angle = determine_skew(img)
         img = rotate(img, angle, resize=True) * 255
+        img = img.astype(np.uint8) # re-cast to unsigned integer; skimage.transform.rotate apparently changes this
 
         # clip scanning boundaries
         img = img[50:-50,50:-50]

--- a/src/ocr_tools.py
+++ b/src/ocr_tools.py
@@ -18,6 +18,8 @@ import src.settings as settings
 from src.processing_tools import get_log_numbers
 
 
+
+
 def get_pages_from_pdf(year = 2019, first_page =1, last_page = 5, plot = False): 
     """ Performs OCR with tesseract on given pages.
 
@@ -40,24 +42,28 @@ def get_pages_from_pdf(year = 2019, first_page =1, last_page = 5, plot = False):
 
     df = pd.DataFrame()
     for i,page in enumerate(pages):
-        page.save(f'out.png', 'png')
+        img = np.array(page) # convert PIL Image to numpy array
 
         # deskew image
-        img = io.imread(f'out.png')
+#        img = io.imread(f'out.png')
         angle = determine_skew(img)
-        img_rotated = rotate(img, angle, resize=True) * 255
-        io.imsave(f'out.png', img_rotated.astype(np.uint8))
+#        img_rotated = rotate(img, angle, resize=True) * 255
+#        io.imsave(f'out.png', img_rotated.astype(np.uint8))
+        img = rotate(img, angle, resize=True) * 255
 
         # clip scanning boundaries
-        img_clipped = img[50:-50,50:-50]
-        cv.imwrite(f'out.png',img_clipped)
-
+#        img_clipped = img[50:-50,50:-50]
+#        cv.imwrite(f'out.png',img_clipped)
+        img = img[50:-50,50:-50]
+        
         # denoise image
-        img = io.imread('out.png')
-        img_denoised = cv.fastNlMeansDenoising(img, h = 50)
+#        img = io.imread('out.png')
+#        img_denoised = cv.fastNlMeansDenoising(img, h = 50)
+        img = cv.fastNlMeansDenoising(img, h = 50)
 
         # binary threshold
-        _ ,img  = cv.threshold(img_denoised,150,255,cv.THRESH_BINARY)
+#        _ ,img  = cv.threshold(img_denoised,150,255,cv.THRESH_BINARY)
+        _ ,img  = cv.threshold(img,150,255,cv.THRESH_BINARY)
 
         # complete ocr
         df_ocr=pytesseract.image_to_data(img,
@@ -112,7 +118,7 @@ def get_pages_from_pdf(year = 2019, first_page =1, last_page = 5, plot = False):
                 plt.savefig(f'{settings.PROJECT_FOLDER}/data/{year}_image_bbox_logs/page_{first_page + i}.png')
                 plt.close(fig)
             
-        os.remove(f"out.png")
+#        os.remove(f"out.png")
         
     return df
 


### PR DESCRIPTION
I haven't tested this at all - but as I'm starting to dig in to Rochester, it looks like there's some unneeded back-and-forth saving steps of processing images to the hard drive? Might be slowing down the processing *a lot*. 

The current version loads the current "draft" of the image from `out.png`, then a single image processing step, then (over)writes `out.png`. 

Since the output of `deskew.io.imread` is a numpy array, then I instead do a single cast of `page` (of type `PIL.PpmImagePlugin.PpmImageFile`) to `np.ndarray`; turns out you can just do `np.array(page)`. For commands after that, I tweaked the processing to look like `img = somefunction(img)`.

I have not tested this - but hoping for from either of you (a) "yes this looks fine" or (b) "no Manuch you're so naive omg". I can also actually test it once and leave a comment before we do an actual pull, if you'd like!